### PR TITLE
BUD 275 - fix(friend): fixed adding friend dialog creating multiple activities

### DIFF
--- a/app/src/main/java/com/codenode/budgetlens/friends/FriendsPageActivity.kt
+++ b/app/src/main/java/com/codenode/budgetlens/friends/FriendsPageActivity.kt
@@ -100,6 +100,7 @@ class FriendsPageActivity : AppCompatActivity() {
             .setMessage("Enter the email of the friend you want to add").setView(emailInput)
             .setPositiveButton("Add", null)
             .setNegativeButton("Cancel") { dialog, _ ->
+                emailInput.text.clear()
                 dialog.dismiss()
             }.create()
 
@@ -109,6 +110,7 @@ class FriendsPageActivity : AppCompatActivity() {
                 if (validateEmail()) {
                     Log.i("FriendPageActivity", "[validated] add : email -> ${emailInput.text}")
                     sendFriendRequest(this, emailInput)
+                    emailInput.text.clear()
                     friendAddDialog.dismiss()
                 }
             }


### PR DESCRIPTION
### BUD Link
[_Bud 275_](https://jira.budgetlens.tech/browse/BUD-275)

### Summary of the PR
- FriendsPageActivity dialog for adding friends no longer will start a new activity each time one of the buttons are clicked.
- The add friend dialog itself will no longer keep retrying to create itself when a user opens it. It should be created once only and then shown instead of fully recreated each time. (Causes a parent view error)
- Dialog will also not close when an error is shown and instead stay open to show it.

### Details
N/A

### UI Photo 
N/A

### Checks

- [x] Tested Changes
