### PR TITLE
feat/bud-276: bug fixed - pass is hidden on boot up

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -49,7 +49,7 @@
         android:background="#FFFFFF"
         android:backgroundTint="#FFFFFF"
         android:hint="@string/password"
-        app:endIconMode="password_toggle"
+        app:passwordToggleEnabled="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -61,7 +61,7 @@
             android:id="@+id/passwordText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:endIconMode="password_toggle" />
+            android:inputType="textPassword"/>
 
     </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
### BUD Link
BUD-276: Password button icon to display hidden text first [https://jira.budgetlens.tech/browse/BUD-276]

### Summary of the PR
password default was not hiding the password. This PR fixes this issue

### Details
Password is now hidden by default

### UI Photo 
![password_hide](https://user-images.githubusercontent.com/60004667/216185986-8d6800b0-d402-4a75-91cb-e63f666c49ab.png)


### Checks

- [X] Tested Changes
- [X] UI is similar to Figma (if applicable)
- [X] Frontend links to Backend (if applicable)
- [ ] Tests are created and working (if applicable)
