### PR TITLE
bug: bud-286/SameFormatForCategories

### DIFF
--- a/app/src/main/java/com/codenode/budgetlens/category/CategoryRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/codenode/budgetlens/category/CategoryRecyclerViewAdapter.kt
@@ -40,7 +40,6 @@ class CategoryRecyclerViewAdapter(private val categories: MutableList<Category>)
         var newCategoryStringArray: Array<String> = emptyArray()
         for (categoryWord in categoryStringArray){
             newCategoryStringArray += categoryWord.replaceFirstChar { it.uppercaseChar() }
-            println(newCategoryStringArray[0])
         }
         holder.categoryName.text = newCategoryStringArray.joinToString(" ")
 


### PR DESCRIPTION
### BUD Link
https://jira.budgetlens.tech/browse/BUD-286 

### Summary of the PR
Makes all categories in category setting page lowercase (Very simple fix). Its in pascal casing now. Eg. `Room`, `Tax Credit`

### UI Photo 
![image](https://user-images.githubusercontent.com/77861893/217932174-308bb88b-7495-4aa8-9472-f3357fb25aa7.png)

### Checks

- [ ] Tested Changes
- [x] UI is similar to Figma (if applicable)
- [x] Frontend links to Backend (if applicable)
- [ ] Tests are created and working (if applicable)
