### PR TITLE
BUG: bud-296_ProperFormFields

### DIFF
--- a/app/src/main/res/layout/activity_add_receipts.xml
+++ b/app/src/main/res/layout/activity_add_receipts.xml
@@ -75,7 +75,8 @@
         android:hint="Location"
         android:drawableRight="@mipmap/location"
         android:inputType="text"
-        android:minHeight="48dp"  />
+        android:minHeight="48dp"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/tx4"
@@ -87,7 +88,8 @@
         android:hint="total"
         android:drawableRight="@mipmap/budget"
         android:inputType="numberDecimal"
-        android:minHeight="48dp"  />
+        android:minHeight="48dp"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/tx5"
@@ -99,7 +101,8 @@
         android:drawableRight="@mipmap/budget"
         android:inputType="numberDecimal"
         android:hint="tax"
-        android:minHeight="48dp"  />
+        android:minHeight="48dp"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/tx6"
@@ -111,7 +114,8 @@
         android:inputType="numberDecimal"
         android:hint="tip"
         android:drawableRight="@mipmap/budget"
-        android:minHeight="48dp"  />
+        android:minHeight="48dp"
+        android:singleLine="true" />
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/tx7"
         android:layout_width="match_parent"
@@ -121,7 +125,8 @@
         android:layout_marginBottom="10dp"
         android:hint="coupon"
         android:drawableRight="@mipmap/budget"
-        android:minHeight="48dp"  />
+        android:minHeight="48dp"
+        android:singleLine="true" />
 
     <TextView
         android:id="@+id/tvCurrency"
@@ -144,7 +149,8 @@
         android:layout_marginBottom="10dp"
         android:hint="receipt text"
         android:drawableRight="@mipmap/ic_rili"
-        android:minHeight="48dp" />
+        android:minHeight="48dp"
+        android:singleLine="true" />
 
     <Button
         android:id="@+id/filledButton"

--- a/app/src/main/res/layout/activity_add_sub_category_pop_up.xml
+++ b/app/src/main/res/layout/activity_add_sub_category_pop_up.xml
@@ -89,7 +89,8 @@
             android:layout_height="match_parent"
             android:background="@color/white"
             android:textSize="50px"
-            android:textAlignment="center"/>
+            android:textAlignment="center"
+            android:singleLine="true" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/activity_code_confimation.xml
+++ b/app/src/main/res/layout/activity_code_confimation.xml
@@ -58,7 +58,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:drawableEnd="@drawable/ic_baseline_lock_24"
-            android:hint="Code" />
+            android:hint="Code"
+            android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <TextView

--- a/app/src/main/res/layout/activity_edit_sub_category_pop_up.xml
+++ b/app/src/main/res/layout/activity_edit_sub_category_pop_up.xml
@@ -61,7 +61,8 @@
             android:layout_height="match_parent"
             android:background="@color/white"
             android:textAlignment="center"
-            android:textSize="50px" />
+            android:textSize="50px"
+            android:singleLine="true" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -36,7 +36,8 @@
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/usernameText"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:singleLine="true" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/activity_new_password.xml
+++ b/app/src/main/res/layout/activity_new_password.xml
@@ -55,7 +55,8 @@
             android:layout_width="match_parent"
             android:hint="New Password"
             android:drawableEnd="@drawable/ic_baseline_lock_24"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -75,7 +76,8 @@
             android:layout_width="match_parent"
             android:hint="Confirm Password"
             android:drawableEnd="@drawable/ic_baseline_lock_24"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <TextView

--- a/app/src/main/res/layout/activity_password_reset.xml
+++ b/app/src/main/res/layout/activity_password_reset.xml
@@ -53,7 +53,8 @@
             android:layout_width="match_parent"
             android:hint="Email address"
             android:drawableEnd="@drawable/ic_baseline_mail_24"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <TextView

--- a/app/src/main/res/layout/activity_receipt.xml
+++ b/app/src/main/res/layout/activity_receipt.xml
@@ -87,7 +87,8 @@
         app:layout_constraintBottom_toTopOf="@+id/location"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/total"
@@ -103,7 +104,8 @@
         app:layout_constraintBottom_toTopOf="@+id/location"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/location"
@@ -119,7 +121,8 @@
         app:layout_constraintBottom_toTopOf="@+id/filledButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/timeOfSale"
@@ -135,7 +138,8 @@
         app:layout_constraintBottom_toTopOf="@+id/filledButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/warranties"
@@ -151,7 +155,8 @@
         app:layout_constraintBottom_toTopOf="@+id/returnDate"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/returnDate"
@@ -167,7 +172,8 @@
         app:layout_constraintBottom_toTopOf="@+id/filledButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <Button
         android:id="@+id/filledButton"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -50,7 +50,8 @@
         app:layout_constraintBottom_toTopOf="@+id/firstName"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/firstName"
@@ -65,7 +66,8 @@
         app:layout_constraintBottom_toTopOf="@+id/lastName"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true"/>
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/lastName"
@@ -80,7 +82,8 @@
         app:layout_constraintBottom_toTopOf="@+id/telephoneNumber"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/telephoneNumber"
@@ -95,7 +98,8 @@
         app:layout_constraintBottom_toTopOf="@+id/password"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/password"
@@ -111,7 +115,8 @@
         app:layout_constraintBottom_toTopOf="@+id/confirmPassword"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/confirmPassword"
@@ -126,7 +131,8 @@
         app:layout_constraintBottom_toTopOf="@+id/filledButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:singleLine="true" />
 
     <Button
         android:id="@+id/outlinedButton"

--- a/app/src/main/res/layout/dialog_add.xml
+++ b/app/src/main/res/layout/dialog_add.xml
@@ -33,7 +33,8 @@
             android:background="@drawable/shape_line_5"
             android:hint="Please add your category name here "
             android:textColor="#333333"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:singleLine="true" />
 
 
         <LinearLayout

--- a/app/src/main/res/layout/edit_profile_dialog.xml
+++ b/app/src/main/res/layout/edit_profile_dialog.xml
@@ -60,7 +60,8 @@
             android:inputType="text"
             android:hint="first name"
             android:ems="10"
-            android:stretchColumns="0" />
+            android:stretchColumns="0"
+            android:nextFocusForward="@+id/lastName" />
 
         <EditText
             android:id="@+id/lastName"

--- a/app/src/main/res/layout/pop_confim_popup.xml
+++ b/app/src/main/res/layout/pop_confim_popup.xml
@@ -33,7 +33,8 @@
             android:lines="4"
             android:layout_marginTop="@dimen/dp_10"
             android:layout_width="match_parent"
-            android:layout_height="50dp"/>
+            android:layout_height="50dp"
+            android:singleLine="true" />
         <View
             android:background="#ff0"
             android:layout_width="match_parent"


### PR DESCRIPTION
### BUD Link
https://jira.budgetlens.tech/browse/BUD-296

### Summary of the PR
Some of the TextView or EditViews, when clicking Enter on the android keys would create a new line rather than moving to the next field in the form.

### Details
For next time, when using a TextView let's make sure to add this line of code in the XML tag `android:singleLine="true"`

### UI Photo 
_Attach an image of the UI (for UI Tasks only). Leave blank if none._
Self-explanatory, try out the pages where the files were edited.

### Checks

- [x ] Tested Changes
- [ ] UI is similar to Figma (if applicable)
- [ ] Frontend links to Backend (if applicable)
- [ ] Tests are created and working (if applicable)
