### PR TITLE
BUD 303 - refactor/ receipt page now has proper sections

### DIFF
--- a/app/src/main/res/layout/activity_receipts_list_page.xml
+++ b/app/src/main/res/layout/activity_receipts_list_page.xml
@@ -8,109 +8,126 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout2"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/topAppBar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:menu="@menu/top_app_bar"
-            app:title="Receipts"/>
+            app:title="Receipts" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/receipts_sort_by_and_filter_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:titleCentered="true">
-
-            <TextView
-                android:id="@+id/receiptsTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="10dp"
-                android:layout_marginStart="16dp"
-                android:textColor="@color/black"
-                android:textSize="22sp"
-                app:layout_constraintStart_toStartOf="@+id/receipts_sort_by_and_filter_bar"
-                app:layout_constraintTop_toTopOf="@+id/receipts_sort_by_and_filter_bar"/>
-
-            <Button
-                android:id="@+id/sort_by_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:backgroundTint="#6750A4"
-                android:text="@string/sort_by"
-                app:icon="@drawable/sort_48px"
-                app:layout_constraintBottom_toBottomOf="@+id/receiptsTextView"
-                app:layout_constraintEnd_toEndOf="@+id/receiptsTextView"
-                app:layout_constraintStart_toStartOf="@+id/receiptsTextView"
-                app:layout_constraintTop_toTopOf="@+id/receiptsTextView"/>
-
-            <Button
-                android:id="@+id/filter_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:backgroundTint="#6750A4"
-                android:text="@string/filter"
-                app:icon="@drawable/filter_alt_48px"
-                app:layout_constraintBottom_toBottomOf="@+id/receiptsTextView"
-                app:layout_constraintEnd_toEndOf="@+id/receiptsTextView"
-                app:layout_constraintHorizontal_bias="0.944"
-                app:layout_constraintStart_toStartOf="@+id/receiptsTextView"
-                app:layout_constraintTop_toTopOf="@+id/receiptsTextView"/>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="10dp"
-            android:orientation="vertical">
-
-            <SearchView
-                android:id="@+id/search_bar_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="15dp"
-                android:layout_marginRight="15dp"
-                android:background="#E7E0EC"
-                android:queryHint="@string/search"
-                android:iconifiedByDefault="false"
-                android:imeOptions="actionSearch"
-                android:inputType="text"
-                android:queryBackground="@android:color/transparent"
-                android:singleLine="true"
-                app:layout_constraintTop_toTopOf="@+id/search_bar"
-                app:startIconDrawable="@drawable/search_48px"/>
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/receipts_list"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="10dp"
-                app:layout_constraintTop_toBottomOf="@id/search_bar_text"
-                android:visibility="gone"/>
-            <ProgressBar
-                android:id="@+id/progressBar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:indeterminate="true"
-                android:padding="10dp"
-                android:visibility="gone"/>
-            <TextView
-                android:id="@+id/empty_view_msg"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="No receipts found. Start scanning!"
-                android:visibility="visible" />
-        </LinearLayout>
 
     </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/receipts_sort_by_and_filter_bar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="64dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:titleCentered="true">
+
+        <TextView
+            android:id="@+id/receiptsTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="10dp"
+            android:layout_marginStart="16dp"
+            android:textColor="@color/black"
+            android:textSize="22sp"
+            app:layout_constraintStart_toStartOf="@+id/receipts_sort_by_and_filter_bar"
+            app:layout_constraintTop_toTopOf="@+id/receipts_sort_by_and_filter_bar" />
+
+        <Button
+            android:id="@+id/sort_by_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:backgroundTint="#6750A4"
+            android:text="@string/sort_by"
+            app:icon="@drawable/sort_48px"
+            app:layout_constraintBottom_toBottomOf="@+id/receiptsTextView"
+            app:layout_constraintEnd_toEndOf="@+id/receiptsTextView"
+            app:layout_constraintStart_toStartOf="@+id/receiptsTextView"
+            app:layout_constraintTop_toTopOf="@+id/receiptsTextView" />
+
+        <Button
+            android:id="@+id/filter_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:backgroundTint="#6750A4"
+            android:text="@string/filter"
+            app:icon="@drawable/filter_alt_48px"
+            app:layout_constraintBottom_toBottomOf="@+id/receiptsTextView"
+            app:layout_constraintEnd_toEndOf="@+id/receiptsTextView"
+            app:layout_constraintHorizontal_bias="0.944"
+            app:layout_constraintStart_toStartOf="@+id/receiptsTextView"
+            app:layout_constraintTop_toTopOf="@+id/receiptsTextView" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/linearLayout3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="9dp"
+        android:layout_marginEnd="10dp"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/receipts_sort_by_and_filter_bar">
+
+        <SearchView
+            android:id="@+id/search_bar_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="15dp"
+            android:layout_marginRight="15dp"
+            android:background="#E7E0EC"
+            android:iconifiedByDefault="false"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
+            android:queryBackground="@android:color/transparent"
+            android:queryHint="@string/search"
+            android:singleLine="true"
+            app:layout_constraintTop_toTopOf="@+id/search_bar"
+            app:startIconDrawable="@drawable/search_48px" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/receipts_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="10dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/search_bar_text" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:indeterminate="true"
+            android:padding="10dp"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/empty_view_msg"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="No receipts found. Start scanning!"
+            android:visibility="visible" />
+    </LinearLayout>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"


### PR DESCRIPTION
### BUD Link
[BUD 303](https://jira.budgetlens.tech/browse/BUD-303)

### Summary of the PR
This PR properly separates the receipt page into 3 appropriate sections instead of 2 of them being merged into 1.

### Details
The page for items also suffered from this, but it was already solved in a previous PR that is already merged.

### UI Photo 
N/A

### Checks

- [x] Tested Changes
- [x] UI is similar to Figma (if applicable)
- [x] Frontend links to Backend (if applicable)
